### PR TITLE
Replace deprecated FluentValidation.AspNetCore package

### DIFF
--- a/backend/Filters/ValidationFilter.cs
+++ b/backend/Filters/ValidationFilter.cs
@@ -1,0 +1,48 @@
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace PruebaTecnicaConfuturo.Filters;
+
+public class ValidationFilter : IAsyncActionFilter
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public ValidationFilter(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        foreach (var argument in context.ActionArguments.Values)
+        {
+            if (argument is null)
+            {
+                continue;
+            }
+
+            var validatorType = typeof(IValidator<>).MakeGenericType(argument.GetType());
+            if (_serviceProvider.GetService(validatorType) is not IValidator validator)
+            {
+                continue;
+            }
+
+            var validationContext = new ValidationContext<object>(argument);
+            var validationResult = await validator.ValidateAsync(validationContext, context.HttpContext.RequestAborted);
+
+            if (!validationResult.IsValid)
+            {
+                foreach (var failure in validationResult.Errors)
+                {
+                    context.ModelState.AddModelError(failure.PropertyName, failure.ErrorMessage);
+                }
+
+                context.Result = new BadRequestObjectResult(context.ModelState);
+                return;
+            }
+        }
+
+        await next();
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,11 +1,11 @@
 using FluentValidation;
-using FluentValidation.AspNetCore;
 using Microsoft.Extensions.Options;
 using PruebaTecnicaConfuturo.Interfaces;
 using PruebaTecnicaConfuturo.Models.Options;
 using PruebaTecnicaConfuturo.Models.Requests;
 using PruebaTecnicaConfuturo.Services;
 using PruebaTecnicaConfuturo.Validators;
+using PruebaTecnicaConfuturo.Filters;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -34,10 +34,12 @@ builder.Services.AddScoped<IWeatherService, WeatherService>();
 builder.Services.AddScoped<IGeolocationService, GeolocationService>();
 
 builder.Services.AddScoped<IValidator<WeatherForecastRequest>, WeatherForecastRequestValidator>();
+builder.Services.AddScoped<ValidationFilter>();
 
-builder.Services.AddControllers();
-
-builder.Services.AddFluentValidationAutoValidation();
+builder.Services.AddControllers(options =>
+{
+    options.Filters.Add<ValidationFilter>();
+});
 
 builder.Services.AddCors(options =>
 {

--- a/backend/PruebaTecnicaConfuturo.csproj
+++ b/backend/PruebaTecnicaConfuturo.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.0.0" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.9" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />


### PR DESCRIPTION
## Summary
- remove the deprecated FluentValidation.AspNetCore package reference from the backend project
- add a reusable MVC action filter that manually triggers FluentValidation validators
- register the new validation filter globally so controller requests continue to be validated

## Testing
- ⚠️ `dotnet build` *(fails: `dotnet` command is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d44511ca2c832ea47e9c6e641ab2b6