### PR TITLE
Skip HTTPS redirect in development

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -64,7 +64,10 @@ if (app.Environment.IsDevelopment())
 
 app.UseCors("AllowFrontend");
 
-app.UseHttpsRedirection();
+if (!app.Environment.IsDevelopment())
+{
+    app.UseHttpsRedirection();
+}
 
 app.MapControllers();
 


### PR DESCRIPTION
## Summary
- disable automatic HTTPS redirection when running in development so that preflight CORS requests are handled correctly

## Testing
- dotnet build *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d45367fcc8832e93e4b295d0e7e8f2