### PR TITLE
Handle nullable strings in weather responses

### DIFF
--- a/frontend/src/services/locationService.ts
+++ b/frontend/src/services/locationService.ts
@@ -3,7 +3,10 @@ import { z, type infer as Infer } from 'zod'
 
 const locationSchema = z.object({
   city: z.string(),
-  region: z.string().optional(),
+  region: z
+    .string()
+    .nullish()
+    .transform((value) => value ?? undefined),
   country: z.string(),
   latitude: z.number(),
   longitude: z.number()

--- a/frontend/src/services/weatherService.ts
+++ b/frontend/src/services/weatherService.ts
@@ -1,18 +1,23 @@
 import { apiClient } from './apiClient'
 import { z, type infer as Infer } from 'zod'
 
+const nullableStringToUndefined = z
+  .string()
+  .nullish()
+  .transform((value) => value ?? undefined)
+
 const dailySchema = z.object({
   date: z.string(),
   temperatureC: z.number(),
   temperatureF: z.number(),
   summary: z.string(),
-  icon: z.string().optional()
+  icon: nullableStringToUndefined
 })
 
 const forecastSchema = z.object({
   location: z.object({
     city: z.string(),
-    region: z.string().optional(),
+    region: nullableStringToUndefined,
     country: z.string(),
     latitude: z.number(),
     longitude: z.number()


### PR DESCRIPTION
## Summary
- normalize nullable strings in weather forecast payloads before validation
- allow null regions from location endpoint to be parsed as undefined on the client

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d454fd4fb4832ea1bae1362c568b1d