### PR TITLE
Add historical weather section alongside forecast

### DIFF
--- a/backend/Domain/Aggregates/ForecastReport.cs
+++ b/backend/Domain/Aggregates/ForecastReport.cs
@@ -7,6 +7,7 @@ public sealed record ForecastReport
 {
     public required Location Location { get; init; }
     public required IReadOnlyCollection<DailyWeather> Daily { get; init; }
+    public required IReadOnlyCollection<DailyWeather> Historical { get; init; }
 
     public static ForecastReport CreateFallback(Location location)
     {
@@ -17,7 +18,7 @@ public sealed record ForecastReport
             "Despejado", "Parcialmente nublado", "Lluvia ligera", "Tormenta", "Nublado"
         };
 
-        var items = Enumerable.Range(0, 7)
+        var upcoming = Enumerable.Range(0, 7)
             .Select(offset => new DailyWeather
             {
                 Date = today.AddDays(offset),
@@ -27,10 +28,22 @@ public sealed record ForecastReport
             })
             .ToList();
 
+        var historical = Enumerable.Range(1, 8)
+            .Select(offset => new DailyWeather
+            {
+                Date = today.AddDays(-offset),
+                Temperature = new Temperature(random.Next(8, 28)),
+                Summary = summaries[(offset + 2) % summaries.Length],
+                Icon = "02n"
+            })
+            .OrderBy(item => item.Date)
+            .ToList();
+
         return new ForecastReport
         {
             Location = location,
-            Daily = items
+            Daily = upcoming,
+            Historical = historical
         };
     }
 }

--- a/backend/Models/Dtos/ForecastResponseDto.cs
+++ b/backend/Models/Dtos/ForecastResponseDto.cs
@@ -7,11 +7,13 @@ public sealed record ForecastResponseDto
 {
     public required LocationDto Location { get; init; }
     public required IReadOnlyCollection<DailyWeatherDto> Daily { get; init; }
+    public required IReadOnlyCollection<DailyWeatherDto> Historical { get; init; }
 
     public static ForecastResponseDto FromDomain(ForecastReport report) => new()
     {
         Location = LocationDto.FromDomain(report.Location),
         Daily = report.Daily.Select(DailyWeatherDto.FromDomain).ToList(),
+        Historical = report.Historical.Select(DailyWeatherDto.FromDomain).ToList(),
     };
 
     public sealed record LocationDto

--- a/backend/Models/External/OpenWeatherTimeMachineResponse.cs
+++ b/backend/Models/External/OpenWeatherTimeMachineResponse.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace PruebaTecnicaConfuturo.Models.External;
+
+public sealed class OpenWeatherTimeMachineResponse
+{
+    [JsonPropertyName("data")]
+    public List<HistoricalData> Data { get; set; } = [];
+
+    public sealed class HistoricalData
+    {
+        [JsonPropertyName("dt")]
+        public long Dt { get; set; }
+
+        [JsonPropertyName("temp")]
+        public double Temperature { get; set; }
+
+        [JsonPropertyName("weather")]
+        public List<WeatherDescription> Weather { get; set; } = [];
+    }
+
+    public sealed class WeatherDescription
+    {
+        [JsonPropertyName("description")]
+        public string? Description { get; set; }
+
+        [JsonPropertyName("icon")]
+        public string? Icon { get; set; }
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,6 +43,11 @@ function App() {
             </p>
           </section>
           <WeatherList items={forecast.daily} />
+          <section className="app__summary">
+            <h2>Histórico de los últimos 7 días</h2>
+            <p>Datos recopilados para la misma ubicación detectada automáticamente.</p>
+          </section>
+          <WeatherList items={forecast.historical} />
         </>
       )}
     </main>

--- a/frontend/src/services/weatherService.ts
+++ b/frontend/src/services/weatherService.ts
@@ -22,7 +22,8 @@ const forecastSchema = z.object({
     latitude: z.number(),
     longitude: z.number()
   }),
-  daily: z.array(dailySchema)
+  daily: z.array(dailySchema),
+  historical: z.array(dailySchema)
 })
 
 export type ForecastResponse = Infer<typeof forecastSchema>


### PR DESCRIPTION
## Summary
- extend the weather report aggregate, DTO and API response to include a 7-day historical block alongside the upcoming forecast
- call OpenWeather's timemachine endpoint to build historical daily summaries and fall back gracefully when data is missing
- surface the historical dataset in the frontend with a new section and schema updates while reusing the existing weather list component

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d45d5f2f84832e8611f5da240881d1