### PR TITLE
Fix historical date conversion to Unix timestamp

### DIFF
--- a/backend/Services/WeatherService.cs
+++ b/backend/Services/WeatherService.cs
@@ -112,7 +112,7 @@ public sealed class WeatherService : IWeatherService
     {
         var baseUri = client.BaseAddress ?? new Uri(_options.BaseUrl!);
         var dates = Enumerable.Range(1, 7)
-            .Select(offset => DateTimeOffset.UtcNow.Date.AddDays(-offset).AddHours(12))
+            .Select(offset => new DateTimeOffset(DateTime.UtcNow.Date.AddDays(-offset).AddHours(12), TimeSpan.Zero))
             .ToArray();
 
         var tasks = dates.Select(async date =>


### PR DESCRIPTION
## Summary
- build historical API query dates as `DateTimeOffset` instances to access `ToUnixTimeSeconds`

## Testing
- `dotnet test` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4624a18ac832e801c521e477975f4