### PR TITLE
Add automated testing suites for backend and frontend

### DIFF
--- a/Prueba_Tecnica_CONFUTURO.sln
+++ b/Prueba_Tecnica_CONFUTURO.sln
@@ -4,17 +4,23 @@ VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PruebaTecnicaConfuturo", "backend\PruebaTecnicaConfuturo.csproj", "{6243BD33-EC07-FFED-01E3-73EF20CCF678}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PruebaTecnicaConfuturo.Tests", "backend.Tests\PruebaTecnicaConfuturo.Tests.csproj", "{3BB92BC4-7264-43BD-B605-C093C8EDFCB4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6243BD33-EC07-FFED-01E3-73EF20CCF678}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6243BD33-EC07-FFED-01E3-73EF20CCF678}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6243BD33-EC07-FFED-01E3-73EF20CCF678}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6243BD33-EC07-FFED-01E3-73EF20CCF678}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{6243BD33-EC07-FFED-01E3-73EF20CCF678}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{6243BD33-EC07-FFED-01E3-73EF20CCF678}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{6243BD33-EC07-FFED-01E3-73EF20CCF678}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{6243BD33-EC07-FFED-01E3-73EF20CCF678}.Release|Any CPU.Build.0 = Release|Any CPU
+{3BB92BC4-7264-43BD-B605-C093C8EDFCB4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{3BB92BC4-7264-43BD-B605-C093C8EDFCB4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{3BB92BC4-7264-43BD-B605-C093C8EDFCB4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{3BB92BC4-7264-43BD-B605-C093C8EDFCB4}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/README.md
+++ b/README.md
@@ -94,7 +94,11 @@ Prueba_Tecnica_CONFUTURO/
    dotnet restore
    dotnet run
    ```
-3. El servicio expone por defecto los endpoints:
+3. Ejecuta los tests automatizados del backend:
+   ```bash
+   dotnet test
+   ```
+4. El servicio expone por defecto los endpoints:
    - `GET /api/location`
    - `GET /api/weather/forecast?latitude={lat}&longitude={lon}`
 
@@ -111,7 +115,11 @@ Prueba_Tecnica_CONFUTURO/
    npm install
    npm run dev
    ```
-3. La aplicación consume únicamente el backend propio y presenta el pronóstico de 7 días con estados de carga y error.
+3. Ejecuta los tests unitarios del frontend (utilizando el compilador de TypeScript y el runner nativo de Node.js):
+   ```bash
+   npm run test
+   ```
+4. La aplicación consume únicamente el backend propio y presenta el pronóstico de 7 días con estados de carga y error.
 
 ---
 
@@ -132,6 +140,6 @@ Prueba_Tecnica_CONFUTURO/
 ---
 
 ## 🧪 Estrategia de validación
-- **Frontend:** compilación de TypeScript y build de Vite para garantizar integridad.
-- **Backend:** al contar con datos simulados, los controladores pueden probarse sin llaves; en un entorno con SDK de .NET se recomienda ejecutar `dotnet test` o al menos `dotnet build`.
+- **Frontend:** tests unitarios escritos en TypeScript y ejecutados con el `node:test` runner tras compilar con `tsc`, además de la build de Vite.
+- **Backend:** suite de pruebas `xUnit` integrada en la solución para verificar los value objects críticos, ejecutable con `dotnet test`.
 

--- a/backend.Tests/Domain/TemperatureTests.cs
+++ b/backend.Tests/Domain/TemperatureTests.cs
@@ -1,0 +1,22 @@
+using PruebaTecnicaConfuturo.Domain.ValueObjects;
+using Xunit;
+
+namespace PruebaTecnicaConfuturo.Tests.Domain;
+
+public class TemperatureTests
+{
+    [Fact]
+    public void ConvertsCelsiusToFahrenheitAndKelvin()
+    {
+        // Arrange
+        var temperature = new Temperature(25);
+
+        // Act
+        var fahrenheit = temperature.Fahrenheit;
+        var kelvin = temperature.Kelvin;
+
+        // Assert
+        Assert.Equal(77.0, fahrenheit);
+        Assert.Equal(298.15, kelvin);
+    }
+}

--- a/backend.Tests/PruebaTecnicaConfuturo.Tests.csproj
+++ b/backend.Tests/PruebaTecnicaConfuturo.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\backend\PruebaTecnicaConfuturo.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-tests
 dist-ssr
 *.local
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "npm run test:build && node --test --experimental-specifier-resolution=node dist-tests/tests",
+    "test:build": "tsc --project tsconfig.tests.json"
   },
   "dependencies": {
     "react": "^19.1.1",

--- a/frontend/src/components/WeatherCard.tsx
+++ b/frontend/src/components/WeatherCard.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames'
+import classNames from '../lib/classnames.js'
 import type { DailyForecast } from '../services/weatherService'
 
 interface WeatherCardProps {

--- a/frontend/src/components/WeatherList.tsx
+++ b/frontend/src/components/WeatherList.tsx
@@ -1,4 +1,4 @@
-import { WeatherCard } from './WeatherCard'
+import { WeatherCard } from './WeatherCard.js'
 import type { DailyForecast } from '../services/weatherService'
 
 interface WeatherListProps {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.tsx'
+import App from './App'
 import { LocationProvider } from './context/LocationContext'
 
 createRoot(document.getElementById('root')!).render(

--- a/frontend/tests/WeatherList.test.tsx
+++ b/frontend/tests/WeatherList.test.tsx
@@ -1,0 +1,35 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+import { WeatherList } from '../src/components/WeatherList.js'
+import type { DailyForecast } from '../src/services/weatherService'
+
+const forecastItems: DailyForecast[] = [
+  {
+    date: '2024-05-01T00:00:00.000Z',
+    temperatureC: 19.5,
+    temperatureF: 67.1,
+    summary: 'Cielo despejado',
+    icon: '01d'
+  },
+  {
+    date: '2024-05-02T00:00:00.000Z',
+    temperatureC: 16.2,
+    temperatureF: 61.2,
+    summary: 'Parcialmente nublado',
+    icon: undefined
+  }
+]
+
+test('WeatherList renders one weather card per forecast item', () => {
+  const html = renderToString(<WeatherList items={forecastItems} />)
+
+  const articleMatches = html.match(/<article class=\"weather-card\"/g) ?? []
+  assert.strictEqual(articleMatches.length, forecastItems.length)
+
+  const iconMatches = html.match(/alt=\"Icono del clima\"/g) ?? []
+  assert.strictEqual(iconMatches.length, 1)
+
+  assert.ok(html.includes('aria-live="polite"'))
+})

--- a/frontend/tests/node-globals.d.ts
+++ b/frontend/tests/node-globals.d.ts
@@ -1,0 +1,14 @@
+declare module 'node:test' {
+  type TestFn = () => void | Promise<void>
+  export function test(name: string, fn: TestFn): void
+}
+
+declare module 'node:assert/strict' {
+  export interface Assert {
+    strictEqual<T>(actual: T, expected: T, message?: string): void
+    ok(value: unknown, message?: string): asserts value
+  }
+
+  const assert: Assert
+  export default assert
+}

--- a/frontend/tsconfig.tests.json
+++ b/frontend/tsconfig.tests.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "outDir": "./dist-tests",
+    "rootDir": "./",
+    "noEmit": false,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "baseUrl": "./",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "types": ["vite/client"],
+    "paths": {
+      "axios": ["./src/lib/axios"],
+      "classnames": ["./src/lib/classnames"],
+      "zod": ["./src/lib/zod"]
+    }
+  },
+  "include": [
+    "tests/**/*.ts",
+    "tests/**/*.tsx",
+    "tests/**/*.d.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ],
+  "exclude": [
+    "dist",
+    "dist-tests",
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- add an xUnit test project to the solution with coverage for the Temperature value object
- configure a lightweight Node.js testing harness for the React client and add a WeatherList rendering test
- document how to run both backend and frontend tests and adjust imports to work with the new compilation step

## Testing
- npm run test
- npm run build
- dotnet test *(fails: command not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d474053af0832eb83d3a7d719e1a92