### PR TITLE
Integrate Open-Meteo forecast service

### DIFF
--- a/backend/Models/External/OpenMeteoArchiveResponse.cs
+++ b/backend/Models/External/OpenMeteoArchiveResponse.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace PruebaTecnicaConfuturo.Models.External;
+
+public sealed class OpenMeteoArchiveResponse
+{
+    [JsonPropertyName("daily")]
+    public OpenMeteoArchiveDaily? Daily { get; set; }
+}
+
+public sealed class OpenMeteoArchiveDaily
+{
+    [JsonPropertyName("time")]
+    public List<string>? Time { get; set; }
+
+    [JsonPropertyName("temperature_2m_mean")]
+    public List<double?>? TemperatureMean { get; set; }
+
+    [JsonPropertyName("weathercode")]
+    public List<int?>? WeatherCode { get; set; }
+}

--- a/backend/Models/External/OpenMeteoForecastResponse.cs
+++ b/backend/Models/External/OpenMeteoForecastResponse.cs
@@ -1,0 +1,33 @@
+using System.Text.Json.Serialization;
+
+namespace PruebaTecnicaConfuturo.Models.External;
+
+public sealed class OpenMeteoForecastResponse
+{
+    [JsonPropertyName("latitude")]
+    public double Latitude { get; set; }
+
+    [JsonPropertyName("longitude")]
+    public double Longitude { get; set; }
+
+    [JsonPropertyName("timezone")]
+    public string? Timezone { get; set; }
+
+    [JsonPropertyName("daily")]
+    public OpenMeteoDailyForecast? Daily { get; set; }
+}
+
+public sealed class OpenMeteoDailyForecast
+{
+    [JsonPropertyName("time")]
+    public List<string>? Time { get; set; }
+
+    [JsonPropertyName("temperature_2m_max")]
+    public List<double?>? TemperatureMax { get; set; }
+
+    [JsonPropertyName("temperature_2m_min")]
+    public List<double?>? TemperatureMin { get; set; }
+
+    [JsonPropertyName("weathercode")]
+    public List<int?>? WeatherCode { get; set; }
+}

--- a/backend/Models/Options/WeatherApiOptions.cs
+++ b/backend/Models/Options/WeatherApiOptions.cs
@@ -2,10 +2,11 @@ namespace PruebaTecnicaConfuturo.Models.Options;
 
 public sealed class WeatherApiOptions
 {
-    public string? BaseUrl { get; set; }
-    public string? ApiKey { get; set; }
-    public string Units { get; set; } = "metric";
-    public string Language { get; set; } = "es";
+    public string? ForecastBaseUrl { get; set; } = "https://api.open-meteo.com/";
+    public string? HistoricalBaseUrl { get; set; } = "https://archive-api.open-meteo.com/";
+    public string Timezone { get; set; } = "auto";
 
-    public bool HasValidConfiguration => !string.IsNullOrWhiteSpace(BaseUrl) && !string.IsNullOrWhiteSpace(ApiKey);
+    public bool HasValidConfiguration =>
+        !string.IsNullOrWhiteSpace(ForecastBaseUrl) &&
+        !string.IsNullOrWhiteSpace(HistoricalBaseUrl);
 }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -16,9 +16,9 @@ builder.Services.Configure<GeolocationApiOptions>(builder.Configuration.GetSecti
 builder.Services.AddHttpClient(WeatherService.HttpClientName, (sp, client) =>
 {
     var options = sp.GetRequiredService<IOptions<WeatherApiOptions>>().Value;
-    if (!string.IsNullOrWhiteSpace(options.BaseUrl))
+    if (!string.IsNullOrWhiteSpace(options.ForecastBaseUrl))
     {
-        client.BaseAddress = new Uri(options.BaseUrl);
+        client.BaseAddress = new Uri(options.ForecastBaseUrl);
     }
 });
 

--- a/backend/Services/WeatherService.cs
+++ b/backend/Services/WeatherService.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Net.Http.Json;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Options;
 using PruebaTecnicaConfuturo.Domain.Aggregates;
 using PruebaTecnicaConfuturo.Domain.Entities;
@@ -15,6 +16,38 @@ public sealed class WeatherService : IWeatherService
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly WeatherApiOptions _options;
     private readonly ILogger<WeatherService> _logger;
+
+    private static readonly IReadOnlyDictionary<int, string> WeatherCodeDescriptions = new Dictionary<int, string>
+    {
+        [0] = "Despejado",
+        [1] = "Principalmente despejado",
+        [2] = "Parcialmente nublado",
+        [3] = "Nublado",
+        [45] = "Niebla",
+        [48] = "Niebla con escarcha",
+        [51] = "Llovizna ligera",
+        [53] = "Llovizna moderada",
+        [55] = "Llovizna intensa",
+        [56] = "Llovizna helada ligera",
+        [57] = "Llovizna helada intensa",
+        [61] = "Lluvia ligera",
+        [63] = "Lluvia moderada",
+        [65] = "Lluvia intensa",
+        [66] = "Lluvia helada ligera",
+        [67] = "Lluvia helada intensa",
+        [71] = "Nieve ligera",
+        [73] = "Nieve moderada",
+        [75] = "Nieve intensa",
+        [77] = "Granizo",
+        [80] = "Chubascos ligeros",
+        [81] = "Chubascos moderados",
+        [82] = "Chubascos intensos",
+        [85] = "Chubascos de nieve ligeros",
+        [86] = "Chubascos de nieve intensos",
+        [95] = "Tormenta eléctrica",
+        [96] = "Tormenta eléctrica con granizo ligero",
+        [99] = "Tormenta eléctrica con granizo intenso"
+    };
 
     public const string HttpClientName = "WeatherApi";
 
@@ -73,102 +106,156 @@ public sealed class WeatherService : IWeatherService
     {
         var query = new Dictionary<string, string?>
         {
-            ["lat"] = location.Coordinates.Latitude.ToString(CultureInfo.InvariantCulture),
-            ["lon"] = location.Coordinates.Longitude.ToString(CultureInfo.InvariantCulture),
-            ["exclude"] = "minutely,hourly,alerts,current",
-            ["appid"] = _options.ApiKey,
-            ["units"] = _options.Units,
-            ["lang"] = _options.Language
+            ["latitude"] = location.Coordinates.Latitude.ToString(CultureInfo.InvariantCulture),
+            ["longitude"] = location.Coordinates.Longitude.ToString(CultureInfo.InvariantCulture),
+            ["timezone"] = string.IsNullOrWhiteSpace(_options.Timezone) ? "auto" : _options.Timezone,
+            ["daily"] = "temperature_2m_max,temperature_2m_min,weathercode"
         };
 
-        var uriBuilder = new UriBuilder(client.BaseAddress ?? new Uri(_options.BaseUrl!))
-        {
-            Path = "data/3.0/onecall",
-            Query = string.Join("&", query.Select(kvp => $"{kvp.Key}={kvp.Value}"))
-        };
+        var baseUri = client.BaseAddress ?? new Uri(_options.ForecastBaseUrl!);
+        var path = QueryHelpers.AddQueryString("v1/forecast", query);
 
-        var response = await client.GetAsync(uriBuilder.Uri, cancellationToken);
+        var response = await client.GetAsync(new Uri(baseUri, path), cancellationToken);
         response.EnsureSuccessStatusCode();
 
-        var payload = await response.Content.ReadFromJsonAsync<OpenWeatherOneCallResponse>(cancellationToken: cancellationToken);
-        if (payload is null)
+        var payload = await response.Content.ReadFromJsonAsync<OpenMeteoForecastResponse>(cancellationToken: cancellationToken);
+        if (payload?.Daily?.Time is null || payload.Daily.Time.Count == 0)
         {
             return Array.Empty<DailyWeather>();
         }
 
-        return payload.Daily
-            .Take(7)
-            .Select(day => new DailyWeather
+        var maxTemperatures = payload.Daily.TemperatureMax ?? new List<double?>();
+        var minTemperatures = payload.Daily.TemperatureMin ?? new List<double?>();
+        var weatherCodes = payload.Daily.WeatherCode ?? new List<int?>();
+
+        var results = new List<DailyWeather>();
+        var items = Math.Min(7, payload.Daily.Time.Count);
+
+        for (var index = 0; index < items; index++)
+        {
+            if (!DateOnly.TryParse(payload.Daily.Time[index], CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
             {
-                Date = DateOnly.FromDateTime(DateTimeOffset.FromUnixTimeSeconds(day.Dt).Date),
-                Temperature = new Temperature(Math.Round(day.Temperature.Day, 1)),
-                Summary = day.Weather.FirstOrDefault()?.Description ?? "Sin descripción",
-                Icon = day.Weather.FirstOrDefault()?.Icon
-            })
-            .ToList();
+                continue;
+            }
+
+            var maxTemperature = index < maxTemperatures.Count ? maxTemperatures[index] : null;
+            var minTemperature = index < minTemperatures.Count ? minTemperatures[index] : null;
+            var temperatureValue = CalculateAverageTemperature(maxTemperature, minTemperature);
+
+            if (temperatureValue is null)
+            {
+                continue;
+            }
+
+            var weatherCode = index < weatherCodes.Count ? weatherCodes[index] : null;
+
+            results.Add(new DailyWeather
+            {
+                Date = date,
+                Temperature = new Temperature(Math.Round(temperatureValue.Value, 1)),
+                Summary = GetSummary(weatherCode),
+                Icon = weatherCode?.ToString(CultureInfo.InvariantCulture)
+            });
+        }
+
+        return results;
     }
 
     private async Task<IReadOnlyCollection<DailyWeather>> FetchHistoricalAsync(HttpClient client, Location location, CancellationToken cancellationToken)
     {
-        var baseUri = client.BaseAddress ?? new Uri(_options.BaseUrl!);
-        var dates = Enumerable.Range(1, 7)
-            .Select(offset => new DateTimeOffset(DateTime.UtcNow.Date.AddDays(-offset).AddHours(12), TimeSpan.Zero))
-            .ToArray();
+        var timezone = string.IsNullOrWhiteSpace(_options.Timezone) ? "auto" : _options.Timezone;
+        var endDate = DateOnly.FromDateTime(DateTime.UtcNow.Date.AddDays(-1));
+        var startDate = endDate.AddDays(-6);
 
-        var tasks = dates.Select(async date =>
+        var query = new Dictionary<string, string?>
         {
-            var query = new Dictionary<string, string?>
+            ["latitude"] = location.Coordinates.Latitude.ToString(CultureInfo.InvariantCulture),
+            ["longitude"] = location.Coordinates.Longitude.ToString(CultureInfo.InvariantCulture),
+            ["timezone"] = timezone,
+            ["start_date"] = startDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            ["end_date"] = endDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            ["daily"] = "temperature_2m_mean,weathercode"
+        };
+
+        var historicalBase = !string.IsNullOrWhiteSpace(_options.HistoricalBaseUrl)
+            ? new Uri(_options.HistoricalBaseUrl)
+            : client.BaseAddress ?? new Uri("https://archive-api.open-meteo.com/");
+
+        var path = QueryHelpers.AddQueryString("v1/archive", query);
+
+        var response = await client.GetAsync(new Uri(historicalBase, path), cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var payload = await response.Content.ReadFromJsonAsync<OpenMeteoArchiveResponse>(cancellationToken: cancellationToken);
+        if (payload?.Daily?.Time is null || payload.Daily.Time.Count == 0)
+        {
+            return Array.Empty<DailyWeather>();
+        }
+
+        var times = payload.Daily.Time;
+        var temperatures = payload.Daily.TemperatureMean ?? new List<double?>();
+        var weatherCodes = payload.Daily.WeatherCode ?? new List<int?>();
+
+        var results = new List<DailyWeather>();
+
+        for (var index = 0; index < times.Count; index++)
+        {
+            if (!DateOnly.TryParse(times[index], CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
             {
-                ["lat"] = location.Coordinates.Latitude.ToString(CultureInfo.InvariantCulture),
-                ["lon"] = location.Coordinates.Longitude.ToString(CultureInfo.InvariantCulture),
-                ["dt"] = date.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture),
-                ["appid"] = _options.ApiKey,
-                ["units"] = _options.Units,
-                ["lang"] = _options.Language
-            };
-
-            var uriBuilder = new UriBuilder(baseUri)
-            {
-                Path = "data/3.0/onecall/timemachine",
-                Query = string.Join("&", query.Select(kvp => $"{kvp.Key}={kvp.Value}"))
-            };
-
-            try
-            {
-                var response = await client.GetAsync(uriBuilder.Uri, cancellationToken);
-                response.EnsureSuccessStatusCode();
-
-                var payload = await response.Content.ReadFromJsonAsync<OpenWeatherTimeMachineResponse>(cancellationToken: cancellationToken);
-                if (payload?.Data is null || payload.Data.Count == 0)
-                {
-                    return null;
-                }
-
-                var averageTemperature = Math.Round(payload.Data.Average(item => item.Temperature), 1);
-                var weatherDescription = payload.Data
-                    .SelectMany(item => item.Weather)
-                    .FirstOrDefault();
-
-                return new DailyWeather
-                {
-                    Date = DateOnly.FromDateTime(date.Date),
-                    Temperature = new Temperature(averageTemperature),
-                    Summary = weatherDescription?.Description ?? "Sin descripción",
-                    Icon = weatherDescription?.Icon
-                };
+                continue;
             }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "No se pudo obtener el clima histórico para {Date}", date.Date.ToShortDateString());
-                return null;
-            }
-        });
 
-        var results = await Task.WhenAll(tasks);
+            var temperatureValue = index < temperatures.Count ? temperatures[index] : null;
+            if (temperatureValue is null)
+            {
+                continue;
+            }
+
+            var weatherCode = index < weatherCodes.Count ? weatherCodes[index] : null;
+
+            results.Add(new DailyWeather
+            {
+                Date = date,
+                Temperature = new Temperature(Math.Round(temperatureValue.Value, 1)),
+                Summary = GetSummary(weatherCode),
+                Icon = weatherCode?.ToString(CultureInfo.InvariantCulture)
+            });
+        }
+
         return results
-            .Where(item => item is not null)
-            .Select(item => item!)
             .OrderBy(item => item.Date)
             .ToList();
+    }
+
+    private static double? CalculateAverageTemperature(double? maxTemperature, double? minTemperature)
+    {
+        if (maxTemperature.HasValue && minTemperature.HasValue)
+        {
+            return (maxTemperature.Value + minTemperature.Value) / 2;
+        }
+
+        if (maxTemperature.HasValue)
+        {
+            return maxTemperature.Value;
+        }
+
+        if (minTemperature.HasValue)
+        {
+            return minTemperature.Value;
+        }
+
+        return null;
+    }
+
+    private static string GetSummary(int? weatherCode)
+    {
+        if (weatherCode is null)
+        {
+            return "Sin descripción";
+        }
+
+        return WeatherCodeDescriptions.TryGetValue(weatherCode.Value, out var description)
+            ? description
+            : $"Código meteorológico {weatherCode.Value}";
     }
 }

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -13,8 +13,9 @@
   },
   "ExternalApis": {
     "Weather": {
-      "BaseUrl": "https://api.openweathermap.org/",
-      "ApiKey": ""
+      "ForecastBaseUrl": "https://api.open-meteo.com/",
+      "HistoricalBaseUrl": "https://archive-api.open-meteo.com/",
+      "Timezone": "auto"
     },
     "Geolocation": {
       "BaseUrl": "https://api.ipgeolocation.io/",


### PR DESCRIPTION
## Summary
- switch the weather service to consume Open-Meteo forecast and archive endpoints and translate weather codes into readable summaries
- add strongly typed Open-Meteo response models plus configuration defaults for forecast, historical base URLs, and timezone
- update dependency injection to use the new configuration schema for the weather HTTP client

## Testing
- dotnet test *(fails: dotnet: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d49ca8c92c832e945f6bba1202c1a5