### PR TITLE
Implement dynamic geolocation in frontend

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,12 @@ function App() {
   const { status: locationStatus, location, error: locationError, refetch } = useLocationContext()
   const { status: weatherStatus, forecast, error: weatherError, refresh } = useWeather()
 
+  const locationParts = location
+    ? [location.city, location.region, location.country].filter((part) =>
+        typeof part === 'string' ? part.trim().length > 0 : Boolean(part)
+      )
+    : []
+
   const isLoading = locationStatus === 'loading' || weatherStatus === 'loading'
   const hasError = locationStatus === 'error' || weatherStatus === 'error'
 
@@ -15,10 +21,8 @@ function App() {
       <header className="app__header">
         <div>
           <h1>Clima en tu ubicación</h1>
-          {location && (
-            <p className="app__subtitle">
-              {location.city}, {location.region ? `${location.region}, ` : ''}{location.country}
-            </p>
+          {location && locationParts.length > 0 && (
+            <p className="app__subtitle">{locationParts.join(', ')}</p>
           )}
         </div>
         <div className="app__actions">

--- a/frontend/src/context/LocationContext.tsx
+++ b/frontend/src/context/LocationContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useMemo, useReducer } from 'react'
+import { createContext, useCallback, useContext, useEffect, useMemo, useReducer } from 'react'
 import { fetchLocation, getDefaultLocation, type LocationDto } from '../services/locationService'
 
 type LocationStatus = 'idle' | 'loading' | 'ready' | 'error'
@@ -19,18 +19,18 @@ type LocationContextValue = LocationState & {
 }
 
 const initialState: LocationState = {
-  status: 'ready',
+  status: 'idle',
   location: getDefaultLocation()
 }
 
 function reducer(state: LocationState, action: LocationAction): LocationState {
   switch (action.type) {
     case 'REQUEST':
-      return { status: 'loading' }
+      return { status: 'loading', location: state.location }
     case 'SUCCESS':
       return { status: 'ready', location: action.payload }
     case 'FAILURE':
-      return { status: 'error', error: action.error }
+      return { status: 'error', location: state.location, error: action.error }
     default:
       return state
   }
@@ -41,22 +41,31 @@ const LocationContext = createContext<LocationContextValue | undefined>(undefine
 export function LocationProvider({ children }: { children: React.ReactNode }) {
   const [state, dispatch] = useReducer(reducer, initialState)
 
+  const resolveLocation = useCallback(async () => {
+    dispatch({ type: 'REQUEST' })
+
+    try {
+      const location = await fetchLocation()
+      dispatch({ type: 'SUCCESS', payload: location })
+    } catch (error) {
+      console.error('Failed to resolve location', error)
+      dispatch({ type: 'FAILURE', error: 'No se pudo obtener la ubicación.' })
+    }
+  }, [])
+
+  useEffect(() => {
+    void resolveLocation()
+  }, [resolveLocation])
+
   const value = useMemo<LocationContextValue>(() => ({
     ...state,
-    refetch: async () => {
-      try {
-        const location = await fetchLocation()
-        dispatch({ type: 'SUCCESS', payload: location })
-      } catch (error) {
-        console.error('Failed to resolve location', error)
-        dispatch({ type: 'FAILURE', error: 'No se pudo obtener la ubicación.' })
-      }
-    }
-  }), [state])
+    refetch: resolveLocation
+  }), [state, resolveLocation])
 
   return <LocationContext.Provider value={value}>{children}</LocationContext.Provider>
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useLocationContext() {
   const context = useContext(LocationContext)
   if (!context) {

--- a/frontend/src/lib/zod.ts
+++ b/frontend/src/lib/zod.ts
@@ -55,7 +55,11 @@ function number(): Schema<number> {
   })
 }
 
-function object<T extends Record<string, Schema<any>>>(shape: T): Schema<{ [K in keyof T]: ReturnType<T[K]['parse']> }> {
+type SchemaShape = Record<string, Schema<unknown>>
+
+type InferShape<T extends SchemaShape> = { [K in keyof T]: ReturnType<T[K]['parse']> }
+
+function object<T extends SchemaShape>(shape: T): Schema<InferShape<T>> {
   return createSchema(input => {
     if (typeof input !== 'object' || input === null) {
       throw new Error('Expected object')
@@ -66,7 +70,7 @@ function object<T extends Record<string, Schema<any>>>(shape: T): Schema<{ [K in
       const schema = shape[key]
       result[key] = schema.parse((input as Record<string, unknown>)[key])
     }
-    return result as { [K in keyof T]: ReturnType<T[K]['parse']> }
+    return result as InferShape<T>
   })
 }
 
@@ -87,4 +91,4 @@ export const z = {
   array
 }
 
-export type infer<T extends Schema<any>> = T extends Schema<infer U> ? U : never
+export type infer<T extends Schema<unknown>> = T extends Schema<infer U> ? U : never

--- a/frontend/src/services/locationService.ts
+++ b/frontend/src/services/locationService.ts
@@ -14,8 +14,42 @@ const fallbackLocation: LocationDto = {
   longitude: -70.6693
 }
 
+function hasGeolocation(): boolean {
+  return typeof navigator !== 'undefined' && 'geolocation' in navigator
+}
+
+function fromGeolocationPosition(position: GeolocationPosition): LocationDto {
+  const { latitude, longitude } = position.coords
+
+  return {
+    city: 'Ubicación detectada',
+    region: undefined,
+    country: '',
+    latitude,
+    longitude
+  }
+}
+
+function resolveWithFallback(resolve: (value: LocationDto) => void) {
+  resolve({ ...fallbackLocation })
+}
+
 export async function fetchLocation(): Promise<LocationDto> {
-  return { ...fallbackLocation }
+  if (!hasGeolocation()) {
+    return { ...fallbackLocation }
+  }
+
+  return await new Promise<LocationDto>((resolve) => {
+    navigator.geolocation.getCurrentPosition(
+      (position) => resolve(fromGeolocationPosition(position)),
+      () => resolveWithFallback(resolve),
+      {
+        enableHighAccuracy: true,
+        timeout: 10000,
+        maximumAge: 5 * 60 * 1000
+      }
+    )
+  })
 }
 
 export function getDefaultLocation(): LocationDto {

--- a/frontend/tests/WeatherList.test.tsx
+++ b/frontend/tests/WeatherList.test.tsx
@@ -25,10 +25,10 @@ const forecastItems: DailyForecast[] = [
 test('WeatherList renders one weather card per forecast item', () => {
   const html = renderToString(<WeatherList items={forecastItems} />)
 
-  const articleMatches = html.match(/<article class=\"weather-card\"/g) ?? []
+  const articleMatches = html.match(/<article class="weather-card"/g) ?? []
   assert.strictEqual(articleMatches.length, forecastItems.length)
 
-  const iconMatches = html.match(/alt=\"Icono del clima\"/g) ?? []
+  const iconMatches = html.match(/alt="Icono del clima"/g) ?? []
   assert.strictEqual(iconMatches.length, 1)
 
   assert.ok(html.includes('aria-live="polite"'))


### PR DESCRIPTION
## Summary
- obtain user coordinates dynamically in the location service using the browser geolocation API with a fallback
- update the location context to resolve the location on mount and reuse a refetch callback
- adjust the UI location label formatting and lint-related helpers/tests to satisfy project linting rules

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d520e5b208832eb70dca129d6a802e