### PR TITLE
Fix axios import and align backend packages with .NET 8

### DIFF
--- a/backend/PruebaTecnicaConfuturo.csproj
+++ b/backend/PruebaTecnicaConfuturo.csproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="FluentValidation" Version="12.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.2" />
     <PackageReference Include="Refit.HttpClientFactory" Version="7.1.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
   </ItemGroup>

--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -1,8 +1,8 @@
-import { create } from 'axios'
+import axios from 'axios'
 
 const baseURL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:5083/api'
 
-export const apiClient = create({
+export const apiClient = axios.create({
   baseURL,
   headers: {
     Accept: 'application/json'


### PR DESCRIPTION
## Summary
- fix the Axios client creation by using the default export so the Vite build can resolve it correctly
- downgrade ASP.NET Core-related packages to 8.x versions that are compatible with the net8.0 target framework

## Testing
- npm run build *(fails: missing packages could not be installed due to registry access restrictions)*
- dotnet build *(fails: `dotnet` CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5302df7bc832e90024eb5d7462a46