### PR TITLE
Adjust header styling and weather icons

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,15 +1,16 @@
 :root {
   color-scheme: light dark;
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background-color: #0b1120;
+  background-color: #1f2937;
   color: #e5e7eb;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at top, rgba(59, 130, 246, 0.35), transparent 60%),
-    radial-gradient(circle at bottom, rgba(16, 185, 129, 0.25), transparent 70%);
+  background: radial-gradient(circle at top, rgba(148, 163, 184, 0.4), transparent 60%),
+    radial-gradient(circle at bottom, rgba(100, 116, 139, 0.35), transparent 70%),
+    #f3f4f6;
 }
 
 #root {
@@ -34,6 +35,7 @@ body {
 .app__header h1 {
   margin: 0;
   font-size: 2.4rem;
+  color: #374151;
 }
 
 .app__subtitle {
@@ -51,8 +53,8 @@ body {
 .app__button {
   border: none;
   border-radius: 999px;
-  background: linear-gradient(135deg, #3b82f6, #06b6d4);
-  color: white;
+  background: #374151;
+  color: #f9fafb;
   padding: 0.75rem 1.5rem;
   font-weight: 600;
   cursor: pointer;
@@ -61,7 +63,7 @@ body {
 
 .app__button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 10px 20px rgba(59, 130, 246, 0.25);
+  box-shadow: 0 10px 20px rgba(55, 65, 81, 0.25);
 }
 
 .app__status {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,14 +4,8 @@ import { useWeather } from './hooks/useWeather'
 import './App.css'
 
 function App() {
-  const { status: locationStatus, location, error: locationError, refetch } = useLocationContext()
+  const { status: locationStatus, error: locationError, refetch } = useLocationContext()
   const { status: weatherStatus, forecast, error: weatherError, refresh } = useWeather()
-
-  const locationParts = location
-    ? [location.city, location.region, location.country].filter((part) =>
-        typeof part === 'string' ? part.trim().length > 0 : Boolean(part)
-      )
-    : []
 
   const isLoading = locationStatus === 'loading' || weatherStatus === 'loading'
   const hasError = locationStatus === 'error' || weatherStatus === 'error'
@@ -21,9 +15,6 @@ function App() {
       <header className="app__header">
         <div>
           <h1>Clima en tu ubicación</h1>
-          {location && locationParts.length > 0 && (
-            <p className="app__subtitle">{locationParts.join(', ')}</p>
-          )}
         </div>
         <div className="app__actions">
           <button type="button" onClick={refetch} className="app__button" aria-label="Actualizar ubicación">

--- a/frontend/src/components/WeatherCard.tsx
+++ b/frontend/src/components/WeatherCard.tsx
@@ -13,13 +13,20 @@ export function WeatherCard({ forecast }: WeatherCardProps) {
     day: 'numeric'
   })
 
+  const openWeatherIconPattern = /^[0-9]{2}[dn]$/i
+  const iconUrl = forecast.icon
+    ? openWeatherIconPattern.test(forecast.icon)
+      ? `https://openweathermap.org/img/wn/${forecast.icon}@2x.png`
+      : `https://open-meteo.com/images/weather-icons/${forecast.icon}.png`
+    : undefined
+
   return (
     <article className="weather-card" aria-label={`Pronóstico para ${formatter.format(date)}`}>
       <header className="weather-card__header">
         <span className="weather-card__day">{formatter.format(date)}</span>
-        {forecast.icon && (
+        {iconUrl && (
           <img
-            src={`https://openweathermap.org/img/wn/${forecast.icon}@2x.png`}
+            src={iconUrl}
             alt="Icono del clima"
             className="weather-card__icon"
             loading="lazy"


### PR DESCRIPTION
## Summary
- update the weather header to remove the location subtitle and align button styling with the new dark grey palette
- refresh the app background with a grey gradient and adjust heading colors to match the requested look
- resolve weather icons by supporting both OpenWeather and Open-Meteo code formats to prevent broken images

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d533110d74832ebbc5e903d2326518