### PR TITLE
Remove weather icon usage

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -110,18 +110,12 @@ body {
 .weather-card__header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
+  justify-content: flex-start;
 }
 
 .weather-card__day {
   font-size: 1.1rem;
   text-transform: capitalize;
-}
-
-.weather-card__icon {
-  width: 64px;
-  height: 64px;
 }
 
 .weather-card__temperature {

--- a/frontend/src/components/WeatherCard.tsx
+++ b/frontend/src/components/WeatherCard.tsx
@@ -13,25 +13,10 @@ export function WeatherCard({ forecast }: WeatherCardProps) {
     day: 'numeric'
   })
 
-  const openWeatherIconPattern = /^[0-9]{2}[dn]$/i
-  const iconUrl = forecast.icon
-    ? openWeatherIconPattern.test(forecast.icon)
-      ? `https://openweathermap.org/img/wn/${forecast.icon}@2x.png`
-      : `https://open-meteo.com/images/weather-icons/${forecast.icon}.png`
-    : undefined
-
   return (
     <article className="weather-card" aria-label={`Pronóstico para ${formatter.format(date)}`}>
       <header className="weather-card__header">
         <span className="weather-card__day">{formatter.format(date)}</span>
-        {iconUrl && (
-          <img
-            src={iconUrl}
-            alt="Icono del clima"
-            className="weather-card__icon"
-            loading="lazy"
-          />
-        )}
       </header>
       <div className="weather-card__body">
         <div className="weather-card__temperature">

--- a/frontend/src/services/weatherService.ts
+++ b/frontend/src/services/weatherService.ts
@@ -10,8 +10,7 @@ const dailySchema = z.object({
   date: z.string(),
   temperatureC: z.number(),
   temperatureF: z.number(),
-  summary: z.string(),
-  icon: nullableStringToUndefined
+  summary: z.string()
 })
 
 const forecastSchema = z.object({

--- a/frontend/tests/WeatherList.test.tsx
+++ b/frontend/tests/WeatherList.test.tsx
@@ -10,15 +10,13 @@ const forecastItems: DailyForecast[] = [
     date: '2024-05-01T00:00:00.000Z',
     temperatureC: 19.5,
     temperatureF: 67.1,
-    summary: 'Cielo despejado',
-    icon: '01d'
+    summary: 'Cielo despejado'
   },
   {
     date: '2024-05-02T00:00:00.000Z',
     temperatureC: 16.2,
     temperatureF: 61.2,
-    summary: 'Parcialmente nublado',
-    icon: undefined
+    summary: 'Parcialmente nublado'
   }
 ]
 
@@ -27,9 +25,6 @@ test('WeatherList renders one weather card per forecast item', () => {
 
   const articleMatches = html.match(/<article class="weather-card"/g) ?? []
   assert.strictEqual(articleMatches.length, forecastItems.length)
-
-  const iconMatches = html.match(/alt="Icono del clima"/g) ?? []
-  assert.strictEqual(iconMatches.length, 1)
 
   assert.ok(html.includes('aria-live="polite"'))
 })


### PR DESCRIPTION
## Summary
- remove all references to weather condition icons from the weather card component and related styles
- simplify the weather service schema and tests to reflect the absence of icon data

## Testing
- `npm run test` *(fails: missing npm dependencies in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d536c8d564832ebdbc610931866651