### PR TITLE
Ajusta pronóstico futuro e histórico y agrega clima de hoy

### DIFF
--- a/backend/Domain/Aggregates/ForecastReport.cs
+++ b/backend/Domain/Aggregates/ForecastReport.cs
@@ -18,7 +18,7 @@ public sealed record ForecastReport
             "Despejado", "Parcialmente nublado", "Lluvia ligera", "Tormenta", "Nublado"
         };
 
-        var upcoming = Enumerable.Range(0, 7)
+        var upcoming = Enumerable.Range(0, 8)
             .Select(offset => new DailyWeather
             {
                 Date = today.AddDays(offset),

--- a/backend/Services/WeatherService.cs
+++ b/backend/Services/WeatherService.cs
@@ -51,6 +51,8 @@ public sealed class WeatherService : IWeatherService
 
     public const string HttpClientName = "WeatherApi";
 
+    private const int UpcomingForecastDays = 8;
+
     public WeatherService(
         IHttpClientFactory httpClientFactory,
         IOptions<WeatherApiOptions> options,
@@ -109,7 +111,8 @@ public sealed class WeatherService : IWeatherService
             ["latitude"] = location.Coordinates.Latitude.ToString(CultureInfo.InvariantCulture),
             ["longitude"] = location.Coordinates.Longitude.ToString(CultureInfo.InvariantCulture),
             ["timezone"] = string.IsNullOrWhiteSpace(_options.Timezone) ? "auto" : _options.Timezone,
-            ["daily"] = "temperature_2m_max,temperature_2m_min,weathercode"
+            ["daily"] = "temperature_2m_max,temperature_2m_min,weathercode",
+            ["forecast_days"] = UpcomingForecastDays.ToString(CultureInfo.InvariantCulture)
         };
 
         var baseUri = client.BaseAddress ?? new Uri(_options.ForecastBaseUrl!);
@@ -129,7 +132,7 @@ public sealed class WeatherService : IWeatherService
         var weatherCodes = payload.Daily.WeatherCode ?? new List<int?>();
 
         var results = new List<DailyWeather>();
-        var items = Math.Min(7, payload.Daily.Time.Count);
+        var items = Math.Min(UpcomingForecastDays, payload.Daily.Time.Count);
 
         for (var index = 0; index < items; index++)
         {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -90,6 +90,58 @@ body {
   margin-bottom: 0.5rem;
 }
 
+.app__today {
+  display: grid;
+  gap: 1rem;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.25), rgba(15, 23, 42, 0.85));
+  border: 1px solid rgba(96, 165, 250, 0.35);
+  border-radius: 20px;
+  padding: 1.75rem;
+  box-shadow: 0 25px 50px -12px rgba(30, 64, 175, 0.35);
+}
+
+.app__today-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.app__today-header h2 {
+  margin: 0;
+  font-size: 1.75rem;
+  color: #f8fafc;
+}
+
+.app__today-header p {
+  margin: 0;
+  font-size: 1.1rem;
+  text-transform: capitalize;
+  color: #bfdbfe;
+}
+
+.app__today-temperature {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: baseline;
+}
+
+.app__today-temperature--primary {
+  font-size: 2.75rem;
+  font-weight: 700;
+}
+
+.app__today-temperature--secondary {
+  font-size: 1.25rem;
+  color: #dbeafe;
+}
+
+.app__today-summary {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #e0f2fe;
+}
+
 .weather-list {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));

--- a/frontend/src/components/WeatherCard.tsx
+++ b/frontend/src/components/WeatherCard.tsx
@@ -5,8 +5,20 @@ interface WeatherCardProps {
   forecast: DailyForecast
 }
 
+function parseForecastDate(value: string) {
+  const [year, month, day] = value.split('-').map(Number)
+
+  if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day)) {
+    return new Date(value)
+  }
+
+  const date = new Date(year, month - 1, day)
+  date.setHours(0, 0, 0, 0)
+  return date
+}
+
 export function WeatherCard({ forecast }: WeatherCardProps) {
-  const date = new Date(forecast.date)
+  const date = parseForecastDate(forecast.date)
   const formatter = new Intl.DateTimeFormat('es-CL', {
     weekday: 'long',
     month: 'short',


### PR DESCRIPTION
## Summary
- corrige el parseo de fechas de las tarjetas para evitar desfases por zona horaria
- agrega un resumen destacado para el clima del día de hoy y limita la grilla futura a partir de mañana
- ajusta la cantidad de días solicitados al backend y el fallback para mantener siete días futuros consistentes

## Testing
- npm run lint
- npm run test *(falla por errores de TypeScript al resolver dependencias externas en el entorno de pruebas)*

------
https://chatgpt.com/codex/tasks/task_e_68d53884bec4832e87486e4f2fc7606e