### PR TITLE
Add weather-themed effects to forecast cards

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -149,14 +149,50 @@ body {
 }
 
 .weather-card {
-  background: rgba(15, 23, 42, 0.75);
-  border-radius: 16px;
-  border: 1px solid rgba(99, 102, 241, 0.15);
-  padding: 1.25rem;
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  border-radius: 18px;
+  border: 1px solid rgba(99, 102, 241, 0.2);
+  padding: 1.35rem;
+  background: linear-gradient(135deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.95));
   box-shadow: 0 25px 50px -12px rgba(30, 64, 175, 0.35);
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+  --weather-card-text-primary: #f8fafc;
+  --weather-card-text-secondary: #cbd5f5;
+}
+
+.weather-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 30px 60px -12px rgba(30, 64, 175, 0.45);
+}
+
+.weather-card__effects {
+  position: absolute;
+  inset: -20%;
+  z-index: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 20% 10%, rgba(96, 165, 250, 0.45), transparent 55%),
+    radial-gradient(circle at 80% 120%, rgba(14, 165, 233, 0.35), transparent 60%);
+  filter: blur(45px);
+  opacity: 0.75;
+  transition: transform 0.6s ease, opacity 0.6s ease;
+}
+
+.weather-card:hover .weather-card__effects {
+  transform: scale(1.05);
+  opacity: 0.95;
+}
+
+.weather-card__header,
+.weather-card__body,
+.weather-card__temperature,
+.weather-card__summary {
+  position: relative;
+  z-index: 1;
 }
 
 .weather-card__header {
@@ -170,6 +206,12 @@ body {
   text-transform: capitalize;
 }
 
+.weather-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
 .weather-card__temperature {
   display: flex;
   flex-direction: column;
@@ -179,16 +221,310 @@ body {
 .weather-card__temperature--primary {
   font-size: 1.75rem;
   font-weight: 700;
+  color: var(--weather-card-text-primary);
 }
 
 .weather-card__temperature--secondary {
   font-size: 1rem;
-  color: #93c5fd;
+  color: var(--weather-card-text-secondary);
 }
 
 .weather-card__summary {
   margin: 0;
-  color: #dbeafe;
+  color: var(--weather-card-text-secondary);
+  font-weight: 500;
+  text-transform: capitalize;
+  letter-spacing: 0.01em;
+}
+
+.weather-card--default .weather-card__effects {
+  background: radial-gradient(circle at 18% 10%, rgba(96, 165, 250, 0.45), transparent 55%),
+    radial-gradient(circle at 82% 120%, rgba(14, 165, 233, 0.35), transparent 60%);
+}
+
+.weather-card--sunny {
+  background: linear-gradient(135deg, rgba(253, 224, 71, 0.85), rgba(249, 115, 22, 0.7));
+  border-color: rgba(251, 191, 36, 0.55);
+  --weather-card-text-primary: #2f1e00;
+  --weather-card-text-secondary: rgba(88, 28, 135, 0.65);
+}
+
+.weather-card--sunny .weather-card__effects {
+  background: radial-gradient(circle at 20% 15%, rgba(253, 224, 71, 0.85), transparent 55%),
+    radial-gradient(circle at 70% 35%, rgba(253, 186, 116, 0.7), transparent 60%);
+  filter: blur(30px);
+  opacity: 0.9;
+}
+
+.weather-card--sunny::after {
+  content: '';
+  position: absolute;
+  top: -50px;
+  right: -40px;
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(253, 224, 71, 0.9) 0%, rgba(253, 224, 71, 0.6) 45%, rgba(255, 255, 255, 0) 70%);
+  box-shadow: 0 0 45px rgba(253, 224, 71, 0.45);
+  animation: weather-card-sun 18s linear infinite;
+  z-index: 0;
+}
+
+@keyframes weather-card-sun {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.weather-card--partly-cloudy {
+  background: linear-gradient(140deg, rgba(129, 140, 248, 0.55), rgba(56, 189, 248, 0.65));
+  border-color: rgba(147, 197, 253, 0.55);
+}
+
+.weather-card--partly-cloudy .weather-card__effects {
+  background: radial-gradient(circle at 20% 40%, rgba(255, 255, 255, 0.55), transparent 60%),
+    radial-gradient(circle at 80% 20%, rgba(255, 255, 255, 0.25), transparent 65%);
+  opacity: 0.9;
+}
+
+.weather-card--partly-cloudy::before {
+  content: '';
+  position: absolute;
+  top: 18px;
+  right: 12px;
+  width: 120px;
+  height: 72px;
+  background: radial-gradient(circle at 30% 55%, rgba(255, 255, 255, 0.85) 0, transparent 60%),
+    radial-gradient(circle at 55% 40%, rgba(255, 255, 255, 0.75) 0, transparent 58%),
+    radial-gradient(circle at 80% 60%, rgba(255, 255, 255, 0.65) 0, transparent 55%);
+  filter: blur(0.5px);
+  opacity: 0.95;
+  z-index: 0;
+}
+
+.weather-card--cloudy {
+  background: linear-gradient(150deg, rgba(100, 116, 139, 0.85), rgba(51, 65, 85, 0.9));
+  border-color: rgba(148, 163, 184, 0.5);
+}
+
+.weather-card--cloudy .weather-card__effects {
+  background: radial-gradient(circle at 15% 25%, rgba(226, 232, 240, 0.4), transparent 55%),
+    radial-gradient(circle at 85% 15%, rgba(148, 163, 184, 0.45), transparent 60%);
+  filter: blur(40px);
+  opacity: 0.85;
+}
+
+.weather-card--cloudy::before {
+  content: '';
+  position: absolute;
+  top: 10px;
+  right: 0;
+  width: 140px;
+  height: 80px;
+  background: radial-gradient(circle at 30% 50%, rgba(255, 255, 255, 0.65) 0, transparent 60%),
+    radial-gradient(circle at 60% 45%, rgba(226, 232, 240, 0.7) 0, transparent 58%),
+    radial-gradient(circle at 80% 55%, rgba(203, 213, 225, 0.6) 0, transparent 55%);
+  opacity: 0.9;
+  filter: blur(2px);
+  z-index: 0;
+}
+
+.weather-card--rainy {
+  background: linear-gradient(160deg, rgba(37, 99, 235, 0.75), rgba(15, 23, 42, 0.95));
+  border-color: rgba(96, 165, 250, 0.45);
+}
+
+.weather-card--rainy .weather-card__effects {
+  background: linear-gradient(180deg, rgba(96, 165, 250, 0.35), transparent 65%);
+  filter: blur(30px);
+  opacity: 0.85;
+}
+
+.weather-card--rainy .weather-card__effects::before {
+  content: '';
+  position: absolute;
+  inset: -40%;
+  background-image: repeating-linear-gradient(120deg, rgba(191, 219, 254, 0.55) 0 6px, transparent 6px 18px);
+  background-size: 120px 120px;
+  animation: weather-card-rain 1.4s linear infinite;
+  opacity: 0.55;
+}
+
+@keyframes weather-card-rain {
+  from {
+    transform: translate3d(0, -30px, 0);
+  }
+
+  to {
+    transform: translate3d(0, 30px, 0);
+  }
+}
+
+.weather-card--storm {
+  background: linear-gradient(170deg, rgba(30, 64, 175, 0.8), rgba(15, 23, 42, 0.96));
+  border-color: rgba(129, 140, 248, 0.55);
+}
+
+.weather-card--storm .weather-card__effects {
+  background: radial-gradient(circle at 30% 30%, rgba(129, 140, 248, 0.35), transparent 60%),
+    radial-gradient(circle at 70% 0%, rgba(248, 250, 252, 0.15), transparent 65%);
+  filter: blur(35px);
+}
+
+.weather-card--storm .weather-card__effects::before {
+  content: '';
+  position: absolute;
+  inset: -40%;
+  background-image: repeating-linear-gradient(120deg, rgba(165, 180, 252, 0.25) 0 4px, transparent 4px 14px);
+  animation: weather-card-rain 1.2s linear infinite;
+  opacity: 0.45;
+}
+
+.weather-card--storm::after {
+  content: '';
+  position: absolute;
+  top: -15%;
+  left: 58%;
+  width: 6px;
+  height: 130%;
+  background: linear-gradient(
+    180deg,
+    rgba(248, 250, 252, 0),
+    rgba(248, 250, 252, 0.95) 45%,
+    rgba(148, 163, 184, 0)
+  );
+  box-shadow: 0 0 35px rgba(248, 250, 252, 0.55);
+  animation: weather-card-lightning 5.5s linear infinite;
+  z-index: 0;
+}
+
+@keyframes weather-card-lightning {
+  0%,
+  82%,
+  100% {
+    opacity: 0;
+    transform: skewX(-12deg);
+  }
+
+  84% {
+    opacity: 1;
+    transform: skewX(6deg);
+  }
+
+  86% {
+    opacity: 0.4;
+  }
+
+  88% {
+    opacity: 1;
+  }
+
+  91% {
+    opacity: 0;
+  }
+}
+
+.weather-card--snowy {
+  background: linear-gradient(155deg, rgba(226, 232, 240, 0.85), rgba(148, 163, 184, 0.75));
+  border-color: rgba(148, 163, 184, 0.6);
+  --weather-card-text-primary: #1e293b;
+  --weather-card-text-secondary: rgba(30, 41, 59, 0.65);
+}
+
+.weather-card--snowy .weather-card__effects {
+  background: radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.85), transparent 60%),
+    radial-gradient(circle at 80% 70%, rgba(226, 232, 240, 0.8), transparent 60%);
+  filter: blur(25px);
+  opacity: 0.95;
+}
+
+.weather-card--snowy .weather-card__effects::before,
+.weather-card--snowy .weather-card__effects::after {
+  content: '';
+  position: absolute;
+  inset: -15%;
+  background-size: 120px 120px;
+  animation: weather-card-snow 12s linear infinite;
+  opacity: 0.75;
+}
+
+.weather-card--snowy .weather-card__effects::before {
+  background-image: radial-gradient(rgba(255, 255, 255, 0.95) 0 3px, rgba(255, 255, 255, 0) 4px);
+}
+
+.weather-card--snowy .weather-card__effects::after {
+  background-image: radial-gradient(rgba(148, 163, 184, 0.6) 0 2px, rgba(148, 163, 184, 0) 3px);
+  background-size: 90px 90px;
+  animation-duration: 18s;
+}
+
+@keyframes weather-card-snow {
+  from {
+    transform: translateY(-25px);
+  }
+
+  to {
+    transform: translateY(25px);
+  }
+}
+
+.weather-card--windy {
+  background: linear-gradient(150deg, rgba(14, 116, 144, 0.8), rgba(12, 74, 110, 0.9));
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+.weather-card--windy .weather-card__effects {
+  background: radial-gradient(circle at 10% 80%, rgba(125, 211, 252, 0.4), transparent 60%),
+    radial-gradient(circle at 85% 15%, rgba(6, 182, 212, 0.35), transparent 65%);
+  filter: blur(35px);
+}
+
+.weather-card--windy .weather-card__effects::before {
+  content: '';
+  position: absolute;
+  inset: -25%;
+  background-image: repeating-linear-gradient(0deg, rgba(224, 242, 254, 0.45) 0 2px, transparent 2px 14px);
+  animation: weather-card-wind 6s ease-in-out infinite;
+  opacity: 0.6;
+}
+
+@keyframes weather-card-wind {
+  0%,
+  100% {
+    transform: translateX(-5%);
+  }
+
+  50% {
+    transform: translateX(5%);
+  }
+}
+
+.weather-card--foggy {
+  background: linear-gradient(155deg, rgba(226, 232, 240, 0.7), rgba(148, 163, 184, 0.85));
+  border-color: rgba(203, 213, 225, 0.6);
+  --weather-card-text-primary: #1f2937;
+  --weather-card-text-secondary: rgba(55, 65, 81, 0.65);
+}
+
+.weather-card--foggy .weather-card__effects {
+  background: radial-gradient(circle at 50% 15%, rgba(255, 255, 255, 0.85), transparent 60%),
+    radial-gradient(circle at 20% 80%, rgba(226, 232, 240, 0.7), transparent 70%);
+  filter: blur(45px);
+  opacity: 0.95;
+}
+
+.weather-card--foggy::before {
+  content: '';
+  position: absolute;
+  inset: -15%;
+  background: radial-gradient(circle at 50% 50%, rgba(248, 250, 252, 0.65), transparent 65%);
+  filter: blur(25px);
+  opacity: 0.7;
+  z-index: 0;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/components/WeatherCard.tsx
+++ b/frontend/src/components/WeatherCard.tsx
@@ -5,6 +5,44 @@ interface WeatherCardProps {
   forecast: DailyForecast
 }
 
+const WEATHER_THEME_RULES: Array<{ className: string; keywords: string[] }> = [
+  { className: 'weather-card--storm', keywords: ['tormenta', 'tempestad', 'electrica'] },
+  { className: 'weather-card--rainy', keywords: ['lluvia', 'llovizna', 'chubasco', 'chaparron'] },
+  { className: 'weather-card--snowy', keywords: ['nieve', 'nevadas', 'nevando', 'nevada'] },
+  { className: 'weather-card--foggy', keywords: ['niebla', 'neblina', 'bruma'] },
+  { className: 'weather-card--windy', keywords: ['viento', 'ventoso', 'rafaga', 'brisa'] },
+  {
+    className: 'weather-card--partly-cloudy',
+    keywords: ['parcialmente nublado', 'intervalos nubosos', 'nubes y sol', 'nuboso']
+  },
+  { className: 'weather-card--cloudy', keywords: ['nublado', 'cubierto', 'overcast'] },
+  { className: 'weather-card--sunny', keywords: ['soleado', 'soleada', 'despejado', 'sol'] }
+]
+
+function normalizeSummary(value: string) {
+  return value
+    .trim()
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+}
+
+function getWeatherThemeClass(summary: string | undefined) {
+  if (!summary) {
+    return 'weather-card--default'
+  }
+
+  const normalized = normalizeSummary(summary)
+
+  for (const theme of WEATHER_THEME_RULES) {
+    if (theme.keywords.some(keyword => normalized.includes(keyword))) {
+      return theme.className
+    }
+  }
+
+  return 'weather-card--default'
+}
+
 function parseForecastDate(value: string) {
   const [year, month, day] = value.split('-').map(Number)
 
@@ -24,9 +62,14 @@ export function WeatherCard({ forecast }: WeatherCardProps) {
     month: 'short',
     day: 'numeric'
   })
+  const themeClass = getWeatherThemeClass(forecast.summary)
 
   return (
-    <article className="weather-card" aria-label={`Pronóstico para ${formatter.format(date)}`}>
+    <article
+      className={classNames('weather-card', themeClass)}
+      aria-label={`Pronóstico para ${formatter.format(date)}`}
+    >
+      <span className="weather-card__effects" aria-hidden="true" />
       <header className="weather-card__header">
         <span className="weather-card__day">{formatter.format(date)}</span>
       </header>


### PR DESCRIPTION
## Summary
- map weather summaries to dedicated theme classes so each WeatherCard can render a matching visual treatment
- design CSS-driven animations, colors, and overlays for sunny, stormy, rainy, snowy, windy, foggy, and default forecast states

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/axios)*

------
https://chatgpt.com/codex/tasks/task_e_68d58c0f8ec4832ea559567af7505c2f