### PR TITLE
Add featured weather box for Brasilia

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -90,6 +90,85 @@ body {
   margin-bottom: 0.5rem;
 }
 
+.app__featured {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.25), rgba(15, 23, 42, 0.85));
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  border-radius: 20px;
+  padding: 1.75rem;
+  box-shadow: 0 25px 45px -12px rgba(37, 99, 235, 0.35);
+}
+
+.app__featured-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.app__featured-header h2 {
+  margin: 0;
+  font-size: 1.75rem;
+  color: #f8fafc;
+}
+
+.app__featured-header p {
+  margin: 0.35rem 0 0;
+  text-transform: capitalize;
+  color: #bfdbfe;
+}
+
+.app__featured-status {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  background: rgba(59, 130, 246, 0.2);
+  border-radius: 12px;
+  color: #e0f2fe;
+}
+
+.app__featured-status--error {
+  background: rgba(239, 68, 68, 0.25);
+  color: #fee2e2;
+}
+
+.app__featured-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.app__featured-temperature {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: baseline;
+}
+
+.app__featured-temperature--primary {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+.app__featured-temperature--secondary {
+  font-size: 1.2rem;
+  color: #dbeafe;
+}
+
+.app__featured-summary {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #e0f2fe;
+}
+
+.app__featured-location {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #cbd5f5;
+}
+
 .app__today {
   display: grid;
   gap: 1rem;

--- a/frontend/src/hooks/useStaticForecast.ts
+++ b/frontend/src/hooks/useStaticForecast.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { fetchForecast, type ForecastResponse } from '../services/weatherService'
+
+type StaticForecastState = {
+  status: 'idle' | 'loading' | 'ready' | 'error'
+  forecast?: ForecastResponse
+  error?: string
+}
+
+type UseStaticForecastOptions = {
+  latitude: number
+  longitude: number
+  errorMessage?: string
+}
+
+const initialState: StaticForecastState = {
+  status: 'idle'
+}
+
+export function useStaticForecast({ latitude, longitude, errorMessage }: UseStaticForecastOptions) {
+  const [state, setState] = useState<StaticForecastState>(initialState)
+
+  const loadForecast = useCallback(async () => {
+    setState({ status: 'loading' })
+
+    try {
+      const data = await fetchForecast(latitude, longitude)
+      setState({ status: 'ready', forecast: data })
+    } catch (error) {
+      console.error('Failed to fetch static forecast', error)
+      setState({
+        status: 'error',
+        error: errorMessage ?? 'No se pudo obtener el pronóstico del clima.'
+      })
+    }
+  }, [latitude, longitude, errorMessage])
+
+  useEffect(() => {
+    loadForecast()
+  }, [loadForecast])
+
+  return useMemo(
+    () => ({
+      ...state,
+      refresh: loadForecast
+    }),
+    [state, loadForecast]
+  )
+}


### PR DESCRIPTION
## Summary
- add a reusable hook to fetch a static forecast for specific coordinates
- show a featured weather panel for Brasília with refresh, status, and location details
- style the new featured panel to match the application's design

## Testing
- `npm run lint` *(fails: missing npm dependencies because packages could not be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5dc00dd0c832e805e40753ec0df5a